### PR TITLE
Removal of 'warnings' invalid parameter

### DIFF
--- a/setup/ui/webpack.config.prod.js
+++ b/setup/ui/webpack.config.prod.js
@@ -25,7 +25,6 @@ module.exports = {
     new ExtractTextPlugin( 'style.css', { allChunks : true } ),
     new UglifyJSPlugin( { uglifyOptions : {
       compress : {
-        warnings : false,
         conditionals : true,
         unused : true,
         comparisons : false,


### PR DESCRIPTION
The 'warnings: false' parameter throws an error that makes the whole build process to fail. Removing it the script works fine, at least for me.